### PR TITLE
Fix Django 2.0 support

### DIFF
--- a/djrichtextfield/widgets.py
+++ b/djrichtextfield/widgets.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 import json
 
-from django.core.urlresolvers import reverse
 from django.forms.widgets import Media, Textarea
+from django.urls import reverse
 from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.html import format_html

--- a/testproject/tests/test_urls.py
+++ b/testproject/tests/test_urls.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.urls import reverse
 
 
 class TestUrls(TestCase):

--- a/testproject/tests/test_views.py
+++ b/testproject/tests/test_views.py
@@ -1,6 +1,6 @@
-from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.urls import reverse
 
 
 @override_settings(DJRICHTEXTFIELD_CONFIG={


### PR DESCRIPTION
- [x] The old import path for reverse is no longer supported in Django 2.0 ( https://docs.djangoproject.com/en/1.11/ref/urlresolvers/ )
- [ ] Update travis to test with Django 2.0
- [ ] Test with Python 3.6