### PR TITLE
Add jQuery from Django admin before the init js

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Django Rich Text Field
 .. image:: https://travis-ci.org/jaap3/django-richtextfield.svg?branch=master
     :target: https://travis-ci.org/jaap3/django-richtextfield
 
-.. image:: https://coveralls.io/repos/jaap3/django-richtextfield/badge.png?branch=master
+.. image:: https://coveralls.io/repos/jaap3/django-richtextfield/badge.svg?branch=master
     :target: https://coveralls.io/r/jaap3/django-richtextfield?branch=master
 
 A Django model field and widget that renders a customizable rich
@@ -21,7 +21,7 @@ Quickstart
 ----------
 
 Install ``django-richtextfield`` and add it to your Django
-project's ``INSTALLED_APPS``::
+project's ``INSTALLED_APPS``, ``django.contrib.admin`` must also be in ``INSTALLED_APPS``::
 
     INSTALLED_APPS += 'djrichtextfield'
 

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,11 @@ Quickstart
 Install ``django-richtextfield`` and add it to your Django
 project's ``INSTALLED_APPS``, ``django.contrib.admin`` must also be in ``INSTALLED_APPS``::
 
-    INSTALLED_APPS += 'djrichtextfield'
+    INSTALLED_APPS = [
+        'django.contrib.admin',
+        ...
+        'djrichtextfield'
+    ]
 
 Add the urls to the project's urlpatterns::
 

--- a/djrichtextfield/widgets.py
+++ b/djrichtextfield/widgets.py
@@ -30,11 +30,11 @@ class RichTextWidget(Textarea):
     @property
     def media(self):
         js = settings.CONFIG['js']
-        js.extend([
+        js += [
             'admin/js/vendor/jquery/jquery.min.js',
             'admin/js/jquery.init.js',
-            reverse(self.INIT_URL))
-        ])
+            reverse(self.INIT_URL)
+        ]
         return Media(js=js)
 
     def get_field_settings(self):

--- a/djrichtextfield/widgets.py
+++ b/djrichtextfield/widgets.py
@@ -32,6 +32,7 @@ class RichTextWidget(Textarea):
         js = settings.CONFIG['js']
         js.extend([
             'admin/js/vendor/jquery/jquery.min.js',
+            'admin/js/jquery.init.js',
             reverse(self.INIT_URL))
         ])
         return Media(js=js)

--- a/djrichtextfield/widgets.py
+++ b/djrichtextfield/widgets.py
@@ -30,7 +30,10 @@ class RichTextWidget(Textarea):
     @property
     def media(self):
         js = settings.CONFIG['js']
-        js.append(reverse(self.INIT_URL))
+        js.extend([
+            'admin/js/vendor/jquery/jquery.min.js',
+            reverse(self.INIT_URL))
+        ])
         return Media(js=js)
 
     def get_field_settings(self):


### PR DESCRIPTION
The init js requires jQuery, so ensure jQuery is always included before it is.