### PR TITLE
Fix container class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 db.sqlite3
 htmlcov
 .coverage
+.tox

--- a/djrichtextfield/widgets.py
+++ b/djrichtextfield/widgets.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import django
 import json
 
 from django.conf import settings as django_settings
@@ -16,7 +17,7 @@ class RichTextWidget(Textarea):
     CSS_CLASS = 'djrichtextfield'
     INIT_URL = 'djrichtextfield_init'
     SETTINGS_ATTR = 'data-field-settings'
-    CONTAINER_CLASS = 'field-box'
+    CONTAINER_CLASS = 'fieldBox' if django.VERSION >= (2, 1) else 'field-box'
     PROFILE_KEY = 'profiles'
 
     def __init__(self, attrs=None, field_settings=None):

--- a/djrichtextfield/widgets.py
+++ b/djrichtextfield/widgets.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
-import django
 import json
+
+import django
 
 from django.conf import settings as django_settings
 from django.forms.widgets import Media, Textarea

--- a/testproject/tests/test_widgets.py
+++ b/testproject/tests/test_widgets.py
@@ -42,7 +42,7 @@ class TestRichTextWidget(TestCase):
 @override_settings(DJRICHTEXTFIELD_CONFIG=CONFIG)
 class SettingsTestCase(TestCase):
     config = CONFIG
-    container_class = 'fieldBox' if django.VERSION >= (2, 1) else 'field-box'
+    container_class = RichTextWidget.CONTAINER_CLASS
 
     def setUp(self):
         self.widget = RichTextWidget()

--- a/testproject/tests/test_widgets.py
+++ b/testproject/tests/test_widgets.py
@@ -1,3 +1,4 @@
+import django
 import json
 
 from django.test import TestCase
@@ -41,6 +42,7 @@ class TestRichTextWidget(TestCase):
 @override_settings(DJRICHTEXTFIELD_CONFIG=CONFIG)
 class SettingsTestCase(TestCase):
     config = CONFIG
+    container_class = 'fieldBox' if django.VERSION >= (2, 1) else 'field-box'
 
     def setUp(self):
         self.widget = RichTextWidget()
@@ -57,10 +59,10 @@ class SettingsTestCase(TestCase):
         and doesn't include any settings.
         """
         widget = RichTextWidget()
-        expected = ('<div class="field-box">'
+        expected = ('<div class="{0}">'
                     '<textarea class="djrichtextfield" cols="40"'
                     ' name="" rows="10">\r\n</textarea>'
-                    '</div>')
+                    '</div>'.format(self.container_class))
         self.assertHTMLEqual(expected, widget.render('', ''))
 
     def test_render_with_settings(self):
@@ -70,11 +72,11 @@ class SettingsTestCase(TestCase):
         settings = {'foo': False}
         widget = RichTextWidget(field_settings=settings)
         config = json.dumps(settings)
-        expected = ('<div class="field-box">'
+        expected = ('<div class="{0}">'
                     '<textarea class="djrichtextfield" cols="40"'
-                    ' data-field-settings="{0}"'
+                    ' data-field-settings="{1}"'
                     ' name="" rows="10">\r\n</textarea>'
-                    '</div>'.format(escape(config)))
+                    '</div>'.format(self.container_class, escape(config)))
         self.assertHTMLEqual(expected, widget.render('', ''))
 
     def test_render_with_profile(self):
@@ -83,11 +85,11 @@ class SettingsTestCase(TestCase):
         """
         widget = RichTextWidget(field_settings='simple')
         config = json.dumps(self.config['profiles']['simple'])
-        expected = ('<div class="field-box">'
+        expected = ('<div class="{0}">'
                     '<textarea class="djrichtextfield" cols="40"'
-                    ' data-field-settings="{0}"'
+                    ' data-field-settings="{1}"'
                     ' name="" rows="10">\r\n</textarea>'
-                    '</div>'.format(escape(config)))
+                    '</div>'.format(self.container_class, escape(config)))
         self.assertHTMLEqual(expected, widget.render('', ''))
 
     def test_render_with_missing_profile(self):
@@ -95,8 +97,8 @@ class SettingsTestCase(TestCase):
         The field gets rendered without a data attribute.
         """
         widget = RichTextWidget(field_settings='missing')
-        expected = ('<div class="field-box">'
+        expected = ('<div class="{0}">'
                     '<textarea class="djrichtextfield" cols="40"'
                     ' name="" rows="10">\r\n</textarea>'
-                    '</div>')
+                    '</div>'.format(self.container_class))
         self.assertHTMLEqual(expected, widget.render('', ''))


### PR DESCRIPTION
Django 2.1.1 changes the container class from field-box to fieldBox.
https://github.com/django/django/commit/5d4d62bf4fe887fcd30f9f0449de07ae76ea5968

Not changing the class breaks the styling.